### PR TITLE
feat: Add localStorage config persistence

### DIFF
--- a/app/components/ConfigPanel.tsx
+++ b/app/components/ConfigPanel.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { FaFloppyDisk, FaXmark } from 'react-icons/fa6';
+import { fadeInUp, tagPop } from '@/app/styles/animations';
+
+interface ConfigPanelProps {
+    activeConfigName: string | null;
+    savedConfigNames: string[];
+    onSave: (name: string) => void;
+    onLoad: (name: string) => void;
+    onDelete: (name: string) => void;
+}
+
+export const ConfigPanel = ({
+    activeConfigName,
+    savedConfigNames,
+    onSave,
+    onLoad,
+    onDelete,
+}: ConfigPanelProps) => {
+    const [isNaming, setIsNaming] = useState(false);
+    const [newName, setNewName] = useState('');
+
+    const handleSave = () => {
+        if (!newName.trim()) return;
+        onSave(newName.trim());
+        setNewName('');
+        setIsNaming(false);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter') handleSave();
+        if (e.key === 'Escape') {
+            setIsNaming(false);
+            setNewName('');
+        }
+    };
+
+    return (
+        <motion.div
+            variants={fadeInUp}
+            initial="initial"
+            animate="animate"
+            className="border-3 border-hero-violet bg-bg-panel p-4 mb-4"
+        >
+            <div className="flex items-center justify-between">
+                <h3
+                    className={`font-black uppercase tracking-wider text-xl ${activeConfigName ? 'text-hero-lavender' : 'text-hero-coral'}`}
+                >
+                    {activeConfigName ? `Config: ${activeConfigName}` : 'Unsaved Config'}
+                </h3>
+                <div className="flex gap-2">
+                    {isNaming ? (
+                        <div className="flex gap-2">
+                            <input
+                                type="text"
+                                value={newName}
+                                onChange={(e) => setNewName(e.target.value)}
+                                onKeyDown={handleKeyDown}
+                                placeholder="Config name"
+                                className="input-brutal px-2 py-1 text-xs w-32"
+                                autoFocus
+                            />
+                            <button onClick={handleSave} className="btn-purple px-2 py-1 text-xs">
+                                Save
+                            </button>
+                            <button
+                                onClick={() => {
+                                    setIsNaming(false);
+                                    setNewName('');
+                                }}
+                                className="btn-outline px-2 py-1 text-xs"
+                            >
+                                Cancel
+                            </button>
+                        </div>
+                    ) : (
+                        <button
+                            onClick={() => setIsNaming(true)}
+                            className="btn-purple px-2 py-1 text-xs flex items-center gap-1"
+                        >
+                            <FaFloppyDisk /> Save As
+                        </button>
+                    )}
+                </div>
+            </div>
+
+            {savedConfigNames.length > 0 && (
+                <div className="flex flex-wrap gap-2 mt-3 pt-3 border-t-2 border-dashed border-hero-violet">
+                    <AnimatePresence mode="popLayout">
+                        {savedConfigNames.map((name) => (
+                            <motion.span
+                                key={name}
+                                layout
+                                variants={tagPop}
+                                initial="initial"
+                                animate="animate"
+                                exit="exit"
+                                onClick={() => onLoad(name)}
+                                className={`tag-brutal cursor-pointer ${
+                                    activeConfigName === name
+                                        ? 'bg-hero-purple text-brutal-black'
+                                        : ''
+                                }`}
+                            >
+                                {name}
+                                <button
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        onDelete(name);
+                                    }}
+                                    className="hover:text-hero-sunset"
+                                >
+                                    <FaXmark />
+                                </button>
+                            </motion.span>
+                        ))}
+                    </AnimatePresence>
+                </div>
+            )}
+        </motion.div>
+    );
+};

--- a/app/components/ConfigPanel.tsx
+++ b/app/components/ConfigPanel.tsx
@@ -30,14 +30,6 @@ export const ConfigPanel = ({
         setIsNaming(false);
     };
 
-    const handleKeyDown = (e: React.KeyboardEvent) => {
-        if (e.key === 'Enter') handleSave();
-        if (e.key === 'Escape') {
-            setIsNaming(false);
-            setNewName('');
-        }
-    };
-
     return (
         <motion.div
             variants={fadeInUp}
@@ -58,7 +50,7 @@ export const ConfigPanel = ({
                                 type="text"
                                 value={newName}
                                 onChange={(e) => setNewName(e.target.value)}
-                                onKeyDown={handleKeyDown}
+                                onKeyDown={(e) => e.key === 'Enter' && handleSave()}
                                 placeholder="Config name"
                                 className="input-brutal px-2 py-1 text-xs w-32"
                                 autoFocus

--- a/app/components/ErrorGenerator.tsx
+++ b/app/components/ErrorGenerator.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
 import { staggerContainer, fadeInUp } from '@/app/styles/animations';
 import { ToastContainer, ToastData, useToast } from '@/app/components/Toast';
 import { ConfirmModal } from '@/app/components/ConfirmModal';
 import { ErrorPreview } from '@/app/components/ErrorPreview';
+import { ConfigPanel } from '@/app/components/ConfigPanel';
 import { DsnInput } from '@/app/components/form/DsnInput';
 import { FormFields } from '@/app/components/form/FormFields';
 import { TagInput } from '@/app/components/form/TagInput';
@@ -13,21 +14,127 @@ import { BatchModePanel } from '@/app/components/form/BatchModePanel';
 import { SkipConfirm } from '@/app/components/form/SkipConfirm';
 import { useErrorForm } from '@/app/hooks/useErrorForm';
 import { useBatchMode } from '@/app/hooks/useBatchMode';
+import { useConfigStorage, ConfigData } from '@/app/hooks/useConfigStorage';
 
 const ErrorGenerator = () => {
-    const [mounted, setMounted] = useState(false);
     const [toasts, setToasts] = useState<ToastData[]>([]);
     const [isOpen, setIsOpen] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
     const [skipConfirm, setSkipConfirm] = useState(false);
+    const [initialLoadDone, setInitialLoadDone] = useState(false);
 
     const showToast = useToast(setToasts);
     const form = useErrorForm(showToast);
     const batch = useBatchMode(showToast);
+    const configStorage = useConfigStorage();
+
+    // Load initial config from localStorage on mount
+    const { loadConfig: loadFormConfig } = form;
+    const { loadConfig: loadBatchConfig } = batch;
 
     useEffect(() => {
-        setMounted(true);
-    }, []);
+        if (configStorage.mounted && !initialLoadDone) {
+            const config = configStorage.currentConfig;
+            loadFormConfig({
+                dsn: config.dsn,
+                message: config.message,
+                priority: config.priority,
+                tags: config.tags,
+                errorCount: config.errorCount,
+                errorsToGenerate: config.errorsToGenerate,
+                fingerprintID: config.fingerprintID,
+            });
+            loadBatchConfig(config.batch);
+            // Set this after state updates are queued, so auto-save waits for next render
+            setInitialLoadDone(true);
+        }
+    }, [
+        configStorage.mounted,
+        configStorage.currentConfig,
+        loadFormConfig,
+        loadBatchConfig,
+        initialLoadDone,
+    ]);
+
+    // Auto-save when form or batch config changes (skip first render after load)
+    const { updateCurrentConfig } = configStorage;
+    const isFirstRenderAfterLoad = useRef(true);
+    const skipNextAutoSave = useRef(false);
+
+    useEffect(() => {
+        if (!configStorage.mounted || !initialLoadDone) return;
+
+        // Skip the first render after initial load to avoid overwriting with stale state
+        if (isFirstRenderAfterLoad.current) {
+            isFirstRenderAfterLoad.current = false;
+            return;
+        }
+
+        // Skip auto-save when loading a saved config
+        if (skipNextAutoSave.current) {
+            skipNextAutoSave.current = false;
+            return;
+        }
+
+        const newConfig: ConfigData = {
+            dsn: form.dsn,
+            message: form.message,
+            priority: form.priority,
+            tags: form.tags,
+            errorCount: form.errorCount,
+            errorsToGenerate: form.errorsToGenerate,
+            fingerprintID: form.fingerprintID,
+            batch: {
+                enabled: batch.enabled,
+                frequency: batch.frequency,
+                repeatCount: batch.repeatCount,
+            },
+        };
+        updateCurrentConfig(newConfig);
+    }, [
+        configStorage.mounted,
+        initialLoadDone,
+        updateCurrentConfig,
+        form.dsn,
+        form.message,
+        form.priority,
+        form.tags,
+        form.errorCount,
+        form.errorsToGenerate,
+        form.fingerprintID,
+        batch.enabled,
+        batch.frequency,
+        batch.repeatCount,
+    ]);
+
+    const handleSaveConfig = (name: string) => {
+        configStorage.saveConfig(name);
+        showToast('Saved', `Config "${name}" saved`, 'success');
+    };
+
+    const handleLoadConfig = (name: string) => {
+        const config = configStorage.savedConfigs[name];
+        if (config) {
+            skipNextAutoSave.current = true;
+            configStorage.loadConfig(name);
+            form.loadConfig({
+                dsn: config.dsn,
+                message: config.message,
+                priority: config.priority,
+                tags: config.tags,
+                errorCount: config.errorCount,
+                errorsToGenerate: config.errorsToGenerate,
+                fingerprintID: config.fingerprintID,
+            });
+            batch.loadConfig(config.batch);
+            showToast('Loaded', `Config "${name}" loaded`, 'success');
+        }
+    };
+
+    const handleDeleteConfig = (name: string) => {
+        configStorage.deleteConfig(name);
+        showToast('Deleted', `Config "${name}" deleted`, 'warning');
+    };
 
     const sendBatch = async () => {
         const response = await fetch('/api/generate-errors', {
@@ -75,11 +182,14 @@ const ErrorGenerator = () => {
             ? 'Start Interval'
             : 'Generate Errors';
 
-    if (!mounted) {
+    if (!configStorage.mounted) {
         return (
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 opacity-0">
                 <div className="flex flex-col gap-4" />
-                <div className="border-3 border-hero-violet bg-bg-panel p-5" />
+                <div className="flex flex-col gap-4">
+                    <div className="border-3 border-hero-violet bg-bg-panel p-4" />
+                    <div className="border-3 border-hero-violet bg-bg-panel p-5 flex-1" />
+                </div>
             </div>
         );
     }
@@ -128,7 +238,16 @@ const ErrorGenerator = () => {
                     </motion.div>
                 </motion.div>
 
-                <ErrorPreview payload={form.getPreviewPayload()} />
+                <div className="flex flex-col">
+                    <ConfigPanel
+                        activeConfigName={configStorage.activeConfigName}
+                        savedConfigNames={configStorage.getConfigNames()}
+                        onSave={handleSaveConfig}
+                        onLoad={handleLoadConfig}
+                        onDelete={handleDeleteConfig}
+                    />
+                    <ErrorPreview payload={form.getPreviewPayload()} />
+                </div>
             </div>
 
             <ConfirmModal

--- a/app/components/form/BatchModePanel.tsx
+++ b/app/components/form/BatchModePanel.tsx
@@ -1,30 +1,12 @@
 'use client';
 
 import { motion, AnimatePresence } from 'framer-motion';
-import { fadeInUp } from '@/app/styles/animations';
+import { fadeInUp, slideInRight, slideInRightItem } from '@/app/styles/animations';
 import { BatchMode } from '@/app/hooks/useBatchMode';
 
 interface BatchModePanelProps {
     batch: BatchMode;
 }
-
-const batchControlsVariants = {
-    hidden: { opacity: 0, x: 20 },
-    visible: {
-        opacity: 1,
-        x: 0,
-        transition: {
-            staggerChildren: 0.05,
-        },
-    },
-    exit: { opacity: 0, x: 20, transition: { duration: 0.15 } },
-};
-
-const batchItemVariants = {
-    hidden: { opacity: 0, x: 10 },
-    visible: { opacity: 1, x: 0 },
-    exit: { opacity: 0, x: 10 },
-};
 
 export const BatchModePanel = ({ batch }: BatchModePanelProps) => {
     const progress = batch.totalRepeats > 0 ? (batch.currentRepeat / batch.totalRepeats) * 100 : 0;
@@ -46,13 +28,13 @@ export const BatchModePanel = ({ batch }: BatchModePanelProps) => {
                     {batch.enabled && (
                         <motion.div
                             className="flex gap-3"
-                            variants={batchControlsVariants}
+                            variants={slideInRight}
                             initial="hidden"
                             animate="visible"
                             exit="exit"
                         >
                             <motion.div
-                                variants={batchItemVariants}
+                                variants={slideInRightItem}
                                 className="flex items-center gap-2"
                             >
                                 <span className="text-sm text-brutal-white/70">every</span>
@@ -66,7 +48,7 @@ export const BatchModePanel = ({ batch }: BatchModePanelProps) => {
                                 <span className="text-sm text-brutal-white/70">sec,</span>
                             </motion.div>
                             <motion.div
-                                variants={batchItemVariants}
+                                variants={slideInRightItem}
                                 className="flex items-center gap-2"
                             >
                                 <input

--- a/app/components/form/BatchModePanel.tsx
+++ b/app/components/form/BatchModePanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { motion } from 'framer-motion';
+import { motion, AnimatePresence } from 'framer-motion';
 import { fadeInUp } from '@/app/styles/animations';
 import { BatchMode } from '@/app/hooks/useBatchMode';
 
@@ -8,12 +8,30 @@ interface BatchModePanelProps {
     batch: BatchMode;
 }
 
+const batchControlsVariants = {
+    hidden: { opacity: 0, x: 20 },
+    visible: {
+        opacity: 1,
+        x: 0,
+        transition: {
+            staggerChildren: 0.05,
+        },
+    },
+    exit: { opacity: 0, x: 20, transition: { duration: 0.15 } },
+};
+
+const batchItemVariants = {
+    hidden: { opacity: 0, x: 10 },
+    visible: { opacity: 1, x: 0 },
+    exit: { opacity: 0, x: 10 },
+};
+
 export const BatchModePanel = ({ batch }: BatchModePanelProps) => {
     const progress = batch.totalRepeats > 0 ? (batch.currentRepeat / batch.totalRepeats) * 100 : 0;
 
     return (
-        <motion.div variants={fadeInUp} className="border-2 border-hero-violet p-3">
-            <div className="flex items-center justify-between">
+        <motion.div variants={fadeInUp} className="border-3 border-hero-violet p-3">
+            <div className="flex items-center justify-between min-h-[2.25rem]">
                 <div className="flex items-center gap-2">
                     <button
                         onClick={() => batch.setEnabled(!batch.enabled)}
@@ -24,31 +42,45 @@ export const BatchModePanel = ({ batch }: BatchModePanelProps) => {
                     </button>
                     <span className="label-brutal !mb-0">Batch Mode</span>
                 </div>
-                {batch.enabled && (
-                    <div className="flex gap-3">
-                        <div className="flex items-center gap-2">
-                            <span className="text-sm text-brutal-white/70">Every</span>
-                            <input
-                                type="number"
-                                min={1}
-                                value={batch.frequency}
-                                onChange={(e) => batch.setFrequency(e.target.value)}
-                                className="input-brutal w-16 px-2 py-1 text-sm text-center"
-                            />
-                            <span className="text-sm text-brutal-white/70">s</span>
-                        </div>
-                        <div className="flex items-center gap-2">
-                            <span className="text-sm text-brutal-white/70">x</span>
-                            <input
-                                type="number"
-                                min={1}
-                                value={batch.repeatCount}
-                                onChange={(e) => batch.setRepeatCount(e.target.value)}
-                                className="input-brutal w-16 px-2 py-1 text-sm text-center"
-                            />
-                        </div>
-                    </div>
-                )}
+                <AnimatePresence mode="wait">
+                    {batch.enabled && (
+                        <motion.div
+                            className="flex gap-3"
+                            variants={batchControlsVariants}
+                            initial="hidden"
+                            animate="visible"
+                            exit="exit"
+                        >
+                            <motion.div
+                                variants={batchItemVariants}
+                                className="flex items-center gap-2"
+                            >
+                                <span className="text-sm text-brutal-white/70">every</span>
+                                <input
+                                    type="number"
+                                    min={1}
+                                    value={batch.frequency}
+                                    onChange={(e) => batch.setFrequency(e.target.value)}
+                                    className="input-brutal w-16 px-2 py-1 text-sm text-center"
+                                />
+                                <span className="text-sm text-brutal-white/70">sec,</span>
+                            </motion.div>
+                            <motion.div
+                                variants={batchItemVariants}
+                                className="flex items-center gap-2"
+                            >
+                                <input
+                                    type="number"
+                                    min={1}
+                                    value={batch.repeatCount}
+                                    onChange={(e) => batch.setRepeatCount(e.target.value)}
+                                    className="input-brutal w-16 px-2 py-1 text-sm text-center"
+                                />
+                                <span className="text-sm text-brutal-white/70">times</span>
+                            </motion.div>
+                        </motion.div>
+                    )}
+                </AnimatePresence>
             </div>
             {batch.isRunning && (
                 <div className="mt-3">

--- a/app/hooks/useBatchMode.ts
+++ b/app/hooks/useBatchMode.ts
@@ -126,6 +126,21 @@ export const useBatchMode = (
         return !isNaN(frequency) && frequency > 0 && !isNaN(repeats) && repeats > 0;
     };
 
+    const getConfig = () => ({
+        enabled: state.enabled,
+        frequency: state.frequency,
+        repeatCount: state.repeatCount,
+    });
+
+    const loadConfig = (config: { enabled: boolean; frequency: string; repeatCount: string }) => {
+        setState((s) => ({
+            ...s,
+            enabled: config.enabled,
+            frequency: config.frequency,
+            repeatCount: config.repeatCount,
+        }));
+    };
+
     return {
         ...state,
         setEnabled,
@@ -135,5 +150,7 @@ export const useBatchMode = (
         execute,
         stop,
         validate,
+        getConfig,
+        loadConfig,
     };
 };

--- a/app/hooks/useConfigStorage.ts
+++ b/app/hooks/useConfigStorage.ts
@@ -1,0 +1,179 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+export interface ConfigData {
+    dsn: string;
+    message: string;
+    priority: 'HIGH' | 'MEDIUM' | 'LOW';
+    tags: Array<{ key: string; value: string }>;
+    errorCount: string;
+    errorsToGenerate: string;
+    fingerprintID: string;
+    batch: {
+        enabled: boolean;
+        frequency: string;
+        repeatCount: string;
+    };
+}
+
+interface SavedConfigs {
+    [name: string]: ConfigData;
+}
+
+const STORAGE_KEY_CURRENT = 'error-generator:current';
+const STORAGE_KEY_SAVED = 'error-generator:saved';
+const STORAGE_KEY_ACTIVE = 'error-generator:active';
+
+const defaultConfig: ConfigData = {
+    dsn: '',
+    message: '',
+    priority: 'HIGH',
+    tags: [],
+    errorCount: '1',
+    errorsToGenerate: '1',
+    fingerprintID: '',
+    batch: {
+        enabled: false,
+        frequency: '30',
+        repeatCount: '5',
+    },
+};
+
+const isValidConfig = (data: unknown): data is ConfigData => {
+    if (!data || typeof data !== 'object') return false;
+    const d = data as Record<string, unknown>;
+    return (
+        typeof d.dsn === 'string' &&
+        typeof d.message === 'string' &&
+        ['HIGH', 'MEDIUM', 'LOW'].includes(d.priority as string) &&
+        Array.isArray(d.tags) &&
+        typeof d.errorCount === 'string' &&
+        typeof d.errorsToGenerate === 'string' &&
+        typeof d.fingerprintID === 'string' &&
+        d.batch !== null &&
+        typeof d.batch === 'object'
+    );
+};
+
+export const useConfigStorage = () => {
+    const [mounted, setMounted] = useState(false);
+    const [currentConfig, setCurrentConfig] = useState<ConfigData>(defaultConfig);
+    const [savedConfigs, setSavedConfigs] = useState<SavedConfigs>({});
+    const [activeConfigName, setActiveConfigName] = useState<string | null>(null);
+    const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+    useEffect(() => {
+        setMounted(true);
+        try {
+            const storedCurrent = localStorage.getItem(STORAGE_KEY_CURRENT);
+            if (storedCurrent) {
+                const parsed = JSON.parse(storedCurrent);
+                if (isValidConfig(parsed)) {
+                    setCurrentConfig(parsed);
+                }
+            }
+            const storedSaved = localStorage.getItem(STORAGE_KEY_SAVED);
+            if (storedSaved) {
+                const parsed = JSON.parse(storedSaved);
+                if (parsed && typeof parsed === 'object') {
+                    setSavedConfigs(parsed);
+                }
+            }
+            const storedActive = localStorage.getItem(STORAGE_KEY_ACTIVE);
+            if (storedActive) {
+                setActiveConfigName(storedActive);
+            }
+        } catch {
+            // Invalid localStorage data, use defaults
+        }
+    }, []);
+
+    const persistCurrent = useCallback((config: ConfigData) => {
+        if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
+        saveTimeoutRef.current = setTimeout(() => {
+            try {
+                localStorage.setItem(STORAGE_KEY_CURRENT, JSON.stringify(config));
+            } catch {
+                // localStorage full or unavailable
+            }
+        }, 300);
+    }, []);
+
+    const updateCurrentConfig = useCallback(
+        (config: ConfigData) => {
+            setCurrentConfig(config);
+            setActiveConfigName(null);
+            if (mounted) {
+                persistCurrent(config);
+                try {
+                    localStorage.removeItem(STORAGE_KEY_ACTIVE);
+                } catch {
+                    // localStorage unavailable
+                }
+            }
+        },
+        [mounted, persistCurrent]
+    );
+
+    const saveConfig = useCallback(
+        (name: string) => {
+            const newSaved = { ...savedConfigs, [name]: currentConfig };
+            setSavedConfigs(newSaved);
+            setActiveConfigName(name);
+            try {
+                localStorage.setItem(STORAGE_KEY_SAVED, JSON.stringify(newSaved));
+                localStorage.setItem(STORAGE_KEY_ACTIVE, name);
+            } catch {
+                // localStorage full or unavailable
+            }
+        },
+        [savedConfigs, currentConfig]
+    );
+
+    const loadConfig = useCallback(
+        (name: string) => {
+            const config = savedConfigs[name];
+            if (config) {
+                setCurrentConfig(config);
+                setActiveConfigName(name);
+                persistCurrent(config);
+                try {
+                    localStorage.setItem(STORAGE_KEY_ACTIVE, name);
+                } catch {
+                    // localStorage full or unavailable
+                }
+            }
+        },
+        [savedConfigs, persistCurrent]
+    );
+
+    const deleteConfig = useCallback(
+        (name: string) => {
+            const { [name]: _deleted, ...rest } = savedConfigs;
+            void _deleted;
+            setSavedConfigs(rest);
+            const clearActive = activeConfigName === name;
+            if (clearActive) setActiveConfigName(null);
+            try {
+                localStorage.setItem(STORAGE_KEY_SAVED, JSON.stringify(rest));
+                if (clearActive) localStorage.removeItem(STORAGE_KEY_ACTIVE);
+            } catch {
+                // localStorage full or unavailable
+            }
+        },
+        [savedConfigs, activeConfigName]
+    );
+
+    const getConfigNames = useCallback(() => Object.keys(savedConfigs), [savedConfigs]);
+
+    return {
+        mounted,
+        currentConfig,
+        savedConfigs,
+        activeConfigName,
+        updateCurrentConfig,
+        saveConfig,
+        loadConfig,
+        deleteConfig,
+        getConfigNames,
+    };
+};

--- a/app/hooks/useErrorForm.ts
+++ b/app/hooks/useErrorForm.ts
@@ -124,6 +124,38 @@ export const useErrorForm = (
         },
     });
 
+    const getConfig = () => ({
+        dsn: form.dsn,
+        message: form.message,
+        priority: form.priority,
+        tags: form.tags,
+        errorCount: form.errorCount,
+        errorsToGenerate: form.errorsToGenerate,
+        fingerprintID: form.fingerprintID,
+    });
+
+    const loadConfig = (config: {
+        dsn: string;
+        message: string;
+        priority: Priority;
+        tags: CustomTag[];
+        errorCount: string;
+        errorsToGenerate: string;
+        fingerprintID: string;
+    }) => {
+        setForm((f) => ({
+            ...f,
+            dsn: config.dsn,
+            message: config.message,
+            priority: config.priority,
+            tags: config.tags,
+            errorCount: config.errorCount,
+            errorsToGenerate: config.errorsToGenerate,
+            fingerprintID: config.fingerprintID,
+            dsnError: '',
+        }));
+    };
+
     return {
         ...form,
         newTagKey,
@@ -137,5 +169,7 @@ export const useErrorForm = (
         validate,
         getPayload,
         getPreviewPayload,
+        getConfig,
+        loadConfig,
     };
 };

--- a/app/styles/animations.ts
+++ b/app/styles/animations.ts
@@ -76,3 +76,19 @@ export const shake: Variants = {
         transition: { duration: 0.4 },
     },
 };
+
+export const slideInRight: Variants = {
+    hidden: { opacity: 0, x: 20 },
+    visible: {
+        opacity: 1,
+        x: 0,
+        transition: { staggerChildren: 0.05 },
+    },
+    exit: { opacity: 0, x: 20, transition: { duration: 0.15 } },
+};
+
+export const slideInRightItem: Variants = {
+    hidden: { opacity: 0, x: 10 },
+    visible: { opacity: 1, x: 0 },
+    exit: { opacity: 0, x: 10 },
+};

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -111,7 +111,7 @@ body {
 }
 
 .input-brutal {
-    background-color: var(--color-brutal-black);
+    background-color: var(--color-bg-panel);
     border: 3px solid var(--color-brutal-white);
     color: var(--color-brutal-white);
     transition:
@@ -135,7 +135,7 @@ body {
 }
 
 .select-brutal {
-    background-color: var(--color-brutal-black);
+    background-color: var(--color-bg-panel);
     border: 3px solid var(--color-brutal-white);
     color: var(--color-brutal-white);
     transition:


### PR DESCRIPTION
Add ability to save and manage multiple named configurations in localStorage,
allowing users to quickly switch between different DSN/tag setups without
re-entering data.

**Changes:**

- Form state auto-saves to localStorage as users type, persisting across refreshes
- Users can save named configurations and switch between them via a new ConfigPanel
- Config panel shows active config name (or "Unsaved Config" in orange when modified)
- Saved configs displayed as clickable tags with individual delete buttons

**Additional polish:**

- Updated input/select backgrounds from pure black to purple-tinted panel color
- Added staggered slide-in animations when enabling batch mode controls
- Fixed batch mode panel height to prevent layout shift when toggling

---


<img width="1331" height="282" alt="image" src="https://github.com/user-attachments/assets/9776188f-e58b-4e3f-b43f-7c15671f89b6" />
