### PR TITLE
feat: add support for multiple issue types with n+1 performance issues

### DIFF
--- a/app/api/performance-target/route.ts
+++ b/app/api/performance-target/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'edge';
+
+export async function GET(request: NextRequest) {
+    const searchParams = request.nextUrl.searchParams;
+    const delay = parseInt(searchParams.get('delay') || '50', 10);
+    const id = searchParams.get('id') || '0';
+
+    const clampedDelay = Math.min(Math.max(delay, 0), 5000);
+    await new Promise((resolve) => setTimeout(resolve, clampedDelay));
+
+    return NextResponse.json({
+        id,
+        timestamp: Date.now(),
+        delay: clampedDelay,
+    });
+}

--- a/app/components/ErrorPreview.tsx
+++ b/app/components/ErrorPreview.tsx
@@ -7,18 +7,24 @@ interface ErrorPreviewProps {
     payload: object;
 }
 
-export const ErrorPreview = ({ payload }: ErrorPreviewProps) => (
-    <motion.div
-        variants={fadeInUp}
-        initial="initial"
-        animate="animate"
-        className="border-3 border-hero-violet bg-bg-panel p-5"
-    >
-        <h3 className="font-black uppercase tracking-wider text-xl text-hero-coral mb-4">
-            Error Preview
-        </h3>
-        <pre className="text-sm text-brutal-white/90 overflow-auto font-mono leading-relaxed">
-            <code>{JSON.stringify(payload, null, 2)}</code>
-        </pre>
-    </motion.div>
-);
+export const ErrorPreview = ({ payload }: ErrorPreviewProps) => {
+    const isPerformance =
+        'type' in payload && (payload as { type: string }).type === 'N+1 API Calls';
+    const title = isPerformance ? 'Performance Issue Preview' : 'Error Preview';
+
+    return (
+        <motion.div
+            variants={fadeInUp}
+            initial="initial"
+            animate="animate"
+            className="border-3 border-hero-violet bg-bg-panel p-5"
+        >
+            <h3 className="font-black uppercase tracking-wider text-xl text-hero-coral mb-4">
+                {title}
+            </h3>
+            <pre className="text-sm text-brutal-white/90 overflow-auto font-mono leading-relaxed">
+                <code>{JSON.stringify(payload, null, 2)}</code>
+            </pre>
+        </motion.div>
+    );
+};

--- a/app/components/form/IssueTypeSelector.tsx
+++ b/app/components/form/IssueTypeSelector.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { fadeInUp } from '@/app/styles/animations';
+import { IssueType, ISSUE_TYPE_CONFIGS } from '@/app/types/issueTypes';
+
+interface IssueTypeSelectorProps {
+    selected: IssueType;
+    onSelect: (type: IssueType) => void;
+}
+
+export const IssueTypeSelector = ({ selected, onSelect }: IssueTypeSelectorProps) => {
+    return (
+        <motion.div variants={fadeInUp} className="border-3 border-hero-violet bg-bg-panel p-4">
+            <label className="label-brutal mb-3 block">Issue Type</label>
+            <div className="flex gap-2 flex-wrap">
+                {ISSUE_TYPE_CONFIGS.map((config) => (
+                    <button
+                        key={config.id}
+                        onClick={() => config.enabled && onSelect(config.id)}
+                        disabled={!config.enabled}
+                        className={`
+                            px-4 py-2 text-sm font-medium border-2 transition-all
+                            ${
+                                selected === config.id
+                                    ? 'border-hero-coral bg-hero-coral text-brutal-black'
+                                    : config.enabled
+                                      ? 'border-hero-violet bg-transparent text-brutal-white hover:border-hero-coral'
+                                      : 'border-gray-600 bg-transparent text-gray-500 cursor-not-allowed opacity-50'
+                            }
+                        `}
+                        title={config.enabled ? config.description : 'Coming soon'}
+                    >
+                        {config.label}
+                        {!config.enabled && <span className="ml-1 text-xs">(soon)</span>}
+                    </button>
+                ))}
+            </div>
+        </motion.div>
+    );
+};

--- a/app/components/form/PerformanceFields.tsx
+++ b/app/components/form/PerformanceFields.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { fadeInUp } from '@/app/styles/animations';
+import { ErrorForm } from '@/app/hooks/useErrorForm';
+
+interface PerformanceFieldsProps {
+    form: ErrorForm;
+}
+
+export const PerformanceFields = ({ form }: PerformanceFieldsProps) => {
+    const { performance, setField } = form;
+
+    const updatePerformance = (key: keyof typeof performance, value: string) => {
+        setField('performance', { ...performance, [key]: value });
+    };
+
+    return (
+        <>
+            <motion.div variants={fadeInUp} className="border-3 border-hero-violet bg-bg-panel p-4">
+                <label className="label-brutal mb-3 block">N+1 API Calls Configuration</label>
+                <div className="grid grid-cols-2 gap-3">
+                    <div>
+                        <label className="label-brutal text-xs">API Call Count</label>
+                        <input
+                            type="number"
+                            min={10}
+                            value={performance.callCount}
+                            onChange={(e) => updatePerformance('callCount', e.target.value)}
+                            className="input-brutal w-full px-3 py-2 text-sm"
+                            placeholder="15"
+                        />
+                        <p className="text-xs text-gray-400 mt-1">Minimum 10 for detection</p>
+                    </div>
+                    <div>
+                        <label className="label-brutal text-xs">Target Delay (ms)</label>
+                        <input
+                            type="number"
+                            min={0}
+                            value={performance.targetDelay}
+                            onChange={(e) => updatePerformance('targetDelay', e.target.value)}
+                            className="input-brutal w-full px-3 py-2 text-sm"
+                            placeholder="50"
+                        />
+                        <p className="text-xs text-gray-400 mt-1">Delay per API call</p>
+                    </div>
+                </div>
+            </motion.div>
+
+            <motion.div variants={fadeInUp} className="border-3 border-hero-violet bg-bg-panel p-4">
+                <label className="label-brutal text-xs">Custom Endpoint (optional)</label>
+                <input
+                    type="text"
+                    value={performance.customEndpoint}
+                    onChange={(e) => updatePerformance('customEndpoint', e.target.value)}
+                    className="input-brutal w-full px-3 py-2 text-sm"
+                    placeholder="Leave empty to use internal endpoint"
+                />
+                <p className="text-xs text-gray-400 mt-1">
+                    Must be a GET endpoint. Uses /api/performance-target if empty.
+                </p>
+            </motion.div>
+        </>
+    );
+};

--- a/app/types/issueTypes.ts
+++ b/app/types/issueTypes.ts
@@ -1,0 +1,47 @@
+export type IssueType = 'error' | 'performance' | 'user_feedback' | 'dead_click';
+
+export interface IssueTypeConfig {
+    id: IssueType;
+    label: string;
+    description: string;
+    enabled: boolean;
+}
+
+export const ISSUE_TYPE_CONFIGS: IssueTypeConfig[] = [
+    {
+        id: 'error',
+        label: 'Error',
+        description: 'Generate error events',
+        enabled: true,
+    },
+    {
+        id: 'performance',
+        label: 'Performance',
+        description: 'Generate N+1 API call issues',
+        enabled: true,
+    },
+    {
+        id: 'user_feedback',
+        label: 'Feedback',
+        description: 'User feedback submissions',
+        enabled: false,
+    },
+    {
+        id: 'dead_click',
+        label: 'Dead Click',
+        description: 'Dead click detection',
+        enabled: false,
+    },
+];
+
+export interface PerformanceConfig {
+    callCount: string;
+    targetDelay: string;
+    customEndpoint: string;
+}
+
+export const DEFAULT_PERFORMANCE_CONFIG: PerformanceConfig = {
+    callCount: '15',
+    targetDelay: '50',
+    customEndpoint: '',
+};


### PR DESCRIPTION
Extend the error generator to support multiple Sentry issue types beyond errors. This adds an issue type selector with Error and Performance options (user feedback and dead clicks shown as coming soon).

The Performance issue type generates N+1 API call detection by making parallel GET requests to a target endpoint and sending the transaction envelope directly to Sentry's API. This allows testing performance issue detection in any Sentry project via DSN.

**Changes:**
- Issue type definitions and selector component
- Performance target endpoint with configurable delay (clamped 0-5000ms)
- Performance fields component for configuring call count and delay
- Direct transaction envelope submission to Sentry API (bypasses SDK to allow custom DSN)
- Backwards-compatible config migration for existing saved configurations

The N+1 detection follows Sentry's requirements: minimum 10 parallel GET requests with `http.client` spans within a `ui.action` transaction.